### PR TITLE
Add kitchen-localhost config

### DIFF
--- a/.kitchen.localhost.yml
+++ b/.kitchen.localhost.yml
@@ -1,0 +1,19 @@
+---
+driver:
+  name: localhost
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus:     <%= ENV['OMNIBUS_CHEF_CLIENT_VERSION'] || '12.3.0' %>
+  data_bags_path:           test/fixtures/data_bags
+
+platforms:
+  - name: local
+
+suites:
+  - name: default
+    run_list:
+      - recipe[bubble::default]
+    attributes:
+      bubble:
+        data_disk: false


### PR DESCRIPTION
Following script converges the local machine

```
# Install ChefDK
curl https://omnitruck.chef.io/install.sh | sudo bash -s -- -c current -P chefdk
eval "$(chef shell-init bash)"

# Git
yum install -y git
git clone https://github.com/MissionCriticalCloud/bubble-cookbook.git

# Install kitchen-localhost gem/plugin
chef gem install kitchen-localhost

# Fix for sudo/chef, do not require rtty
sed 's/\(^Defaults[ \t]*requiretty\)/#\1/g' -i /etc/sudoers

# Use the specific kitchen file for convergence
cd bubble-cookbook/
export KITCHEN_LOCAL_YAML=.kitchen.localhost.yml
kitchen converge

# To finish, reboot is required
reboot
```
