### PR TITLE
Enforce (local repo) line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Declare files that will always have LF line endings on checkout.
+*.py text eol=lf
+*.sh text eol=lf
+*.batch text eol=lf
+rc.local text eol=lf
+ifcfg-tap_vpn eol=lf
+ifcfg-virbr0.50 eol=lf

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -18,4 +18,8 @@ describe 'bubble::default' do
     its(:stdout) { should match(/NAT\s+active/)}
   end
 
+  describe command('brctl show') do
+    its(:stdout) { should contain('tap_vpn')}
+    its(:stdout) { should contain('virbr0-nic')}
+  end
 end


### PR DESCRIPTION
When checking-out files, git will automatically replace LF by CRLF when using Windows.

When kitchen uploads the cookbook to the guest, no conversion is done.

Thereby the created Linux guest would have (bash (-included)) scripts containing CRLF, which messes up (especially) setting environment variables, resulting in failing configurations, such as the interface definitions of tap_vpn and virbr0.50.
