### PR TITLE
Create directories recursively

### DIFF
--- a/recipes/nfs.rb
+++ b/recipes/nfs.rb
@@ -1,9 +1,5 @@
 # Create base structure for NFS server
-%w( /data
-    /data/storage
-    /data/storage/primary
-    /data/storage/secondary
-    /data/storage/secondary/MCCT-SHARED-1
+%w( /data/storage/secondary/MCCT-SHARED-1
     /data/storage/secondary/MCCT-SHARED-2
     /data/storage/secondary/MCCT-SHARED-3
     /data/storage/primary/MCCT-XEN-1
@@ -17,6 +13,7 @@
     group node['bubble']['group_name']
     mode '0755'
     action :create
+    recursive true
   end
 end
 


### PR DESCRIPTION
Thereby resolves Chef warnings:

```
WARN: Cloning resource attributes for directory[/data] from prior resource (CHEF-3694)
WARN: Previous directory[/data]: /home/root/kitchen/cache/cookbooks/bubble/recipes/data_disk.rb:5:in `from_file'
WARN: Current  directory[/data]: /home/root/kitchen/cache/cookbooks/bubble/recipes/nfs.rb:15:in `block in from_file'
```

as `/data` was created here and in the data_disk recipe.
