### PR TITLE
Manage home for the coredns user.

### DIFF
--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -12,6 +12,7 @@ user 'coredns' do
   gid node['bubble']['group_name']
   home '/home/coredns'
   shell '/bin/bash'
+  manage_home true
 end
 
 # Create directory for coredns binary


### PR DESCRIPTION
This fixes the issue in which on new deploys the coredns user wouldn't be created.
