### PR TITLE
Ensure installation epel-release before other packages

### DIFF
--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -1,25 +1,20 @@
 # Packages for virt-manager and kvm
-package %w(epel-release centos-release-qemu-ev vlgothic-fonts adwaita-gtk3-theme
+
+package 'epel-release'
+
+package %w(centos-release-qemu-ev vlgothic-fonts adwaita-gtk3-theme
            kvm virt-manager libvirt virt-install qemu-kvm xauth
-           dejavu-lgc-sans-fonts) do
-  action :install
-end
+           dejavu-lgc-sans-fonts)
 
 # Extra tools
 package %w(git virt-top screen vim openssh-askpass supervisor deltarpm sshpass
-           byobu bash-completion nmap) do
-  action :install
-end
+           byobu bash-completion nmap)
 
 # libguestfs-tools for manipulating images
-package %w(libguestfs-tools) do
-  action :install
-end
+package 'libguestfs-tools'
 
 # Python packages for the deploy scripts
-package %w(python-pip python-bottle python-argparse python-jinja2) do
-  action :install
-end
+package %w(python-pip python-bottle python-argparse python-jinja2)
 
 # Packages for running marvin (compile scripts) on the bubble itself
 # remove maven yum package if present
@@ -29,9 +24,7 @@ end
 include_recipe 'maven::default'
 
 package %w(python-paramiko ws-commons-util genisoimage gcc python MySQL-python
-           mariadb mysql-connector-python) do
-  action :install
-end
+           mariadb mysql-connector-python)
 
 # required java & tools
 # Upgrade openjdk to 'latest' due to enhanced crypto support
@@ -39,17 +32,11 @@ package 'java-1.8.0-openjdk-devel.x86_64' do
   action :upgrade
 end
 
-package %w(apache-commons-daemon-jsvc libffi-devel) do
-  action :install
-end
+package %w(apache-commons-daemon-jsvc libffi-devel)
 
 # tools & clients
 package %w(mariadb-server nc nfs-utils openssh-clients openssl-devel rpm-build
-           setroubleshoot wget) do
-  action :install
-end
+           setroubleshoot wget)
 
 # python & ruby tooling
-package %w(python-devel python-ecdsa python-setuptools rubygems) do
-  action :install
-end
+package %w(python-devel python-ecdsa python-setuptools rubygems)


### PR DESCRIPTION
When installed in a single transaction with other packages which
require the epel-repo, other packages will break the transaction

thereby breaking the (very first) chef run.